### PR TITLE
fix(mac): update brew cask installations by removing deprecated tools and specifying the correct IntelliJ version

### DIFF
--- a/mac
+++ b/mac
@@ -128,7 +128,7 @@ install_brew_cask firefox
 install_brew_cask docker
 install_brew_package gh
 install_brew_cask google-drive
-install_brew_cask intellij-idea-ce
+install_brew_cask intellij-idea
 install_brew_cask sublime-text
 install_brew_cask visual-studio-code
 install_brew_package vim
@@ -136,7 +136,6 @@ install_brew_cask iterm2
 install_brew_cask lastpass
 install_brew_cask libreoffice
 install_brew_cask maccy
-install_brew_cask macdown
 install_brew_cask obsidian
 install_brew_cask numi
 install_brew_cask notion


### PR DESCRIPTION
## Description

* Intellij Idea has been moved to a [unified distribution](https://lp.jetbrains.com/intellij-idea-unified-faq/?_gl=1*k2h8gn*_gcl_au*MjE0MzQwNjY2Mi4xNzcyNDM0OTMz*FPAU*MjE0MzQwNjY2Mi4xNzcyNDM0OTMz*_ga*MTQ2MDI4MjIxNy4xNzcyNDM0OTMz*_ga_9J976DJZ68*czE3NzI2MDQxNzQkbzYkZzEkdDE3NzI2MDQyODckajEzJGwwJGgw&_cl=MTsxOzE7V0RGVllDN0xQTXZlS1RIdjd1VU9DWTV2bVFSUmtjTmdTcVdxYU9lbDJjcHFYUDNXMDF4bW9mN2RrWlJHcFlVYTs=). Meaning both CE and Ultimate edition are same now. The `intellij-idea-ce` in homebrew has been deprecated, hence replacing it with `intellij-idea`
* MacDown has also been deprecated, and the alternative for it are obsidian, vs code, etc which are already there, hence removing it as well.